### PR TITLE
Create workflows for FlowCrafter

### DIFF
--- a/json/style.yml
+++ b/json/style.yml
@@ -1,0 +1,16 @@
+style:
+  name: Check style
+  runs-on: ubuntu-latest
+
+  needs: detect-changes
+  if: needs.detect-changes.outputs.any_changed == 'true'
+
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: prettier
+      uses: creyD/prettier_action@v4.3
+      with:
+        dry: true
+        prettier_options: "--check **/*.json"

--- a/json/workflow.yml
+++ b/json/workflow.yml
@@ -1,0 +1,33 @@
+---
+name: JSON
+
+"on":
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  detect-changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+
+    outputs:
+      any_changed: ${{ steps.detect-changes.outputs.any_changed }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Get changed files
+        id: detect-changes
+        uses: tj-actions/changed-files@v35
+        with:
+          files: |
+            **/*.json
+
+      - name: Print changed files
+        run: |
+          for file in ${{ steps.changed-files-specific.outputs.all_changed_files }}; do
+            echo "$file"
+          done

--- a/markdown/lint.yml
+++ b/markdown/lint.yml
@@ -1,0 +1,15 @@
+lint:
+  name: Lint code
+  runs-on: ubuntu-latest
+
+  needs: detect-changes
+  if: needs.detect-changes.outputs.any_changed == 'true'
+
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: markdownlint-cli
+      uses: nosborn/github-action-markdown-cli@v3.3.0
+      with:
+        files: "**.md"

--- a/markdown/style.yml
+++ b/markdown/style.yml
@@ -1,0 +1,16 @@
+style:
+  name: Check style
+  runs-on: ubuntu-latest
+
+  needs: detect-changes
+  if: needs.detect-changes.outputs.any_changed == 'true'
+
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: prettier
+      uses: creyD/prettier_action@v4.3
+      with:
+        dry: true
+        prettier_options: "--check **/*.md"

--- a/markdown/workflow.yml
+++ b/markdown/workflow.yml
@@ -1,0 +1,33 @@
+---
+name: Markdown
+
+"on":
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  detect-changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+
+    outputs:
+      any_changed: ${{ steps.detect-changes.outputs.any_changed }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Get changed files
+        id: detect-changes
+        uses: tj-actions/changed-files@v35
+        with:
+          files: |
+            **/*.md
+
+      - name: Print changed files
+        run: |
+          for file in ${{ steps.changed-files-specific.outputs.all_changed_files }}; do
+            echo "$file"
+          done

--- a/yaml/lint.yml
+++ b/yaml/lint.yml
@@ -1,0 +1,13 @@
+lint:
+  name: Lint code
+  runs-on: ubuntu-latest
+
+  needs: detect-changes
+  if: needs.detect-changes.outputs.any_changed == 'true'
+
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Run yamllint
+      uses: actionshub/yamllint@v1.7.1

--- a/yaml/style.yml
+++ b/yaml/style.yml
@@ -1,0 +1,16 @@
+style:
+  name: Check style
+  runs-on: ubuntu-latest
+
+  needs: detect-changes
+  if: needs.detect-changes.outputs.any_changed == 'true'
+
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: prettier
+      uses: creyD/prettier_action@v4.3
+      with:
+        dry: true
+        prettier_options: "--check **/*.{yml,yaml}"

--- a/yaml/workflow.yml
+++ b/yaml/workflow.yml
@@ -1,0 +1,34 @@
+---
+name: YAML
+
+"on":
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  detect-changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+
+    outputs:
+      any_changed: ${{ steps.detect-changes.outputs.any_changed }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Get changed files
+        id: detect-changes
+        uses: tj-actions/changed-files@v35
+        with:
+          files: |
+            **/*.yaml
+            **/*.yml
+
+      - name: Print changed files
+        run: |
+          for file in ${{ steps.changed-files-specific.outputs.all_changed_files }}; do
+            echo "$file"
+          done


### PR DESCRIPTION
FlowCrafter[^1] is a command-line tool that makes it easy to manage workflows for GitHub Actions using reusable snippets. This repository contains our templates that we use in other projects. Snippets for common file types have been created, others will follow.

[^1]: https://github.com/jdno/flowcrafter