### PR TITLE
Build Docker image for Rust workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,60 @@
+---
+name: Docker
+
+"on":
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    name: Build and push
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        dockerfile:
+          - rust/Dockerfile
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Get image name from Dockerfile name
+        id: name
+        run: |
+          image_name=gha-$(echo ${{ matrix.dockerfile }} | cut -d '/' -f 1)
+          echo "image_name=$image_name" >> $GITHUB_OUTPUT
+          echo "$image_name"
+
+      - name: Collect metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/${{ steps.name.outputs.image_name }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          file: ${{ matrix.dockerfile }}
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,0 +1,4 @@
+FROM rust:1.70.0
+
+# Install Clippy and rustfmt
+RUN rustup component add clippy rustfmt


### PR DESCRIPTION
We are pre-building a Docker image for GitHub Actions that test Rust projects. Pre-building the image speeds up the tests, and gives us more control over the execution environment.