### PR TITLE
Grant GitHub Actions permissions to upload packages

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,10 @@ name: Docker
       - main
   pull_request:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     name: Build and push


### PR DESCRIPTION
The workflow that pre-builds the Docker images has been given permission to push images into GitHub's container registry.