### PR TITLE
Create workflows for Rust

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -2,3 +2,7 @@ FROM rust:1.70.0
 
 # Install Clippy and rustfmt
 RUN rustup component add clippy rustfmt
+
+# Build and test all feature flag combinations for a crate
+# https://github.com/frewsxcv/cargo-all-features
+RUN cargo install cargo-all-features

--- a/rust/features.yml
+++ b/rust/features.yml
@@ -1,0 +1,19 @@
+features:
+  name: Test feature flags
+  runs-on: ubuntu-latest
+
+  needs: detect-changes
+  if: needs.detect-changes.outputs.any_changed == 'true'
+
+  container:
+    image: ghcr.io/otterbuild/gha-rust:main
+
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Cache build artifacts
+      uses: swatinem/rust-cache@v2.2.1
+
+    - name: Test all feature flag combinations
+      run: cargo test-all-features

--- a/rust/lint.yml
+++ b/rust/lint.yml
@@ -1,0 +1,19 @@
+lint:
+  name: Lint code
+  runs-on: ubuntu-latest
+
+  needs: detect-changes
+  if: needs.detect-changes.outputs.any_changed == 'true'
+
+  container:
+    image: ghcr.io/otterbuild/gha-rust:main
+
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Cache build artifacts
+      uses: swatinem/rust-cache@v2.2.1
+
+    - name: Run Clippy
+      run: cargo clippy --all-targets --all-features -- -D warnings

--- a/rust/style.yml
+++ b/rust/style.yml
@@ -1,0 +1,16 @@
+style:
+  name: Check style
+  runs-on: ubuntu-latest
+
+  needs: detect-changes
+  if: needs.detect-changes.outputs.any_changed == 'true'
+
+  container:
+    image: ghcr.io/otterbuild/gha-rust:main
+
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Run Rustfmt
+      run: cargo fmt --all -- --check

--- a/rust/test.yml
+++ b/rust/test.yml
@@ -1,0 +1,39 @@
+test:
+  name: Run tests
+  runs-on: ubuntu-latest
+
+  needs: detect-changes
+  if: needs.detect-changes.outputs.any_changed == 'true'
+
+  container:
+    image: xd009642/tarpaulin:develop-nightly
+    options: --security-opt seccomp=unconfined
+
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Cache build artifacts
+      uses: swatinem/rust-cache@v2.2.1
+
+    - name: Run tests with test coverage
+      run: |
+        cargo +nightly tarpaulin \
+          --verbose \
+          --all-features \
+          --workspace \
+          --timeout 120 \
+          --target-dir target/tarpaulin-target/ \
+          --skip-clean \
+          --out Xml
+
+    - name: Upload to codecov.io
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+
+    - name: Archive code coverage results
+      uses: actions/upload-artifact@v3
+      with:
+        name: code-coverage-report
+        path: cobertura.xml

--- a/rust/workflow.yml
+++ b/rust/workflow.yml
@@ -1,0 +1,38 @@
+---
+name: Rust
+
+"on":
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_PROFILE_TEST_DEBUG: 0
+
+jobs:
+  detect-changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+
+    outputs:
+      any_changed: ${{ steps.detect-changes.outputs.any_changed }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Get changed files
+        id: detect-changes
+        uses: tj-actions/changed-files@v35
+        with:
+          files: |
+            **/*.rs
+            **/*.toml
+
+      - name: Print changed files
+        run: |
+          for file in ${{ steps.changed-files-specific.outputs.all_changed_files }}; do
+            echo "$file"
+          done


### PR DESCRIPTION
A set of common workflows has been created for our Rust-based projects. The workflows build the project, run the tests, check formatting with rustfmt, and run Clippy against all targets. Additionally, all possible combinations of feature flags can be tested.